### PR TITLE
Prevent exception if text is None

### DIFF
--- a/SlideRunner/dataAccess/annotations.py
+++ b/SlideRunner/dataAccess/annotations.py
@@ -320,7 +320,7 @@ class rectangularAnnotation(annotation):
 
             image = cv2.rectangle(image, thickness=thickness, pt1=(xpos1,ypos1), pt2=(xpos2,ypos2),color=self.getColor(vp), lineType=cv2.LINE_AA)
 
-           if self.text is not None and (len(self.text)>0) and (zoomLevel < self.minimumAnnotationLabelZoom):
+            if self.text is not None and (len(self.text)>0) and (zoomLevel < self.minimumAnnotationLabelZoom):
                   cv2.putText(image, self.text, (xpos1+3, ypos2+10), cv2.FONT_HERSHEY_PLAIN , 0.7,(0,0,0),1,cv2.LINE_AA)
 
 class polygonAnnotation(annotation):

--- a/SlideRunner/dataAccess/annotations.py
+++ b/SlideRunner/dataAccess/annotations.py
@@ -320,7 +320,7 @@ class rectangularAnnotation(annotation):
 
             image = cv2.rectangle(image, thickness=thickness, pt1=(xpos1,ypos1), pt2=(xpos2,ypos2),color=self.getColor(vp), lineType=cv2.LINE_AA)
 
-            if (len(self.text)>0) and (zoomLevel < self.minimumAnnotationLabelZoom):
+           if self.text is not None and (len(self.text)>0) and (zoomLevel < self.minimumAnnotationLabelZoom):
                   cv2.putText(image, self.text, (xpos1+3, ypos2+10), cv2.FONT_HERSHEY_PLAIN , 0.7,(0,0,0),1,cv2.LINE_AA)
 
 class polygonAnnotation(annotation):


### PR DESCRIPTION
Code to reproduce the exception:
SlideRunner Version: SlideRunner-1.31.0-

DB = Database()
DB.create("SDATA_Final_Annotations.sqlite")
DB.insertAnnotator('EXACT')
DB.insertClass('0')
DB.insertNewSlide(slide,image_path)

DB.insertNewAreaAnnotation(x1=int(vector['x1']),
                                       y1=int(vector['y1']),
                                       x2=int(vector['x2']),
                                       y2=int(vector['y2']), 
                                       slideUID=image_id, 
                                       classID=label_id, 
                                       annotator=1)